### PR TITLE
[WIP]chat-space　DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,39 @@ Things you may want to cover:
 
 * ...
 
+## postsテーブル
+|Colum|Type|Options|  
+|-----|----|-------|  
+|image|text|
+|text|text|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
+## usersテーブル
+|Colum|Type|Options|  
+|-----|----|-------|  
+|Name|string|null: false|
+|Email|string|null: false|
+|Password|string|null: false|
+
+### Association
+- has_many :posts
+- has_many :groups, through: :groups_users
+
+
+## groupsテーブル
+|Colum|Type|Options|  
+|-----|----|-------|  
+|group_name|string|null: false|
+
+### Association
+- has_many : posts
+- has_many : users, through: :groups_users
+
 ## groups_usersテーブル
 
 |Colum|Type|Options|  

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Things you may want to cover:
 |image|text|
 |text|text|
 |user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foregin_key: ture|
 
 ### Association
 - belongs_to :user
@@ -38,30 +39,30 @@ Things you may want to cover:
 ## usersテーブル
 |Colum|Type|Options|  
 |-----|----|-------|  
-|Name|string|null: false|
-|Email|string|null: false|
-|Password|string|null: false|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
 
 ### Association
 - has_many :posts
 - has_many :groups, through: :groups_users
-
+- has_many :groups_users
 
 ## groupsテーブル
 |Colum|Type|Options|  
 |-----|----|-------|  
-|group_name|string|null: false|
+|name|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many : posts
-- has_many : users, through: :groups_users
+- has_many :posts
+- has_many :users, through: :groups_users
+- has_many :groups_users
 
 ## groups_usersテーブル
 
 |Colum|Type|Options|  
 |-----|----|-------|  
-|user_id|integer|null: false, foregin_key: true|  
 |group_id|integer|null: false, foregin_key: true|  
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Colum|Type|Options|  
+|-----|----|-------|  
+|user_id|integer|null: false, foregin_key: true|  
+|group_id|integer|null: false, foregin_key: true|  
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Things you may want to cover:
 |Colum|Type|Options|  
 |-----|----|-------|  
 |name|string|null: false|
-|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :posts
@@ -63,7 +62,8 @@ Things you may want to cover:
 
 |Colum|Type|Options|  
 |-----|----|-------|  
-|group_id|integer|null: false, foregin_key: true|  
+|group_id|integer|null: false, foregin_key: true|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Things you may want to cover:
 |Colum|Type|Options|  
 |-----|----|-------|  
 |group_name|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many : posts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-end
+ends

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-ends
+end


### PR DESCRIPTION
# What
chat-spaceのDBを実装する。
posts, users, groups, groups_usersの4つのテーブルに分けてDB設計
アソシエーションの記載あり

# why
chat-spaceのデータを保存・管理するために必須のため